### PR TITLE
Guard against untracked default changes

### DIFF
--- a/Fasting.xcodeproj/project.pbxproj
+++ b/Fasting.xcodeproj/project.pbxproj
@@ -817,13 +817,13 @@
 		922C1D00263A573500F34AE9 /* WatchFasting Extension */ = {
 			isa = PBXGroup;
 			children = (
-				92ADC0A0263B6D9E009B348F /* Application */,
+				922C1D10263A573500F34AE9 /* Info.plist */,
 				922C1D0B263A573500F34AE9 /* Assets.xcassets */,
 				9200EF3D264101DA00111355 /* Colors.xcassets */,
+				92ADC0A0263B6D9E009B348F /* Application */,
 				92ADC0A1263B6F76009B348F /* Complications */,
 				92ADC095263B5E64009B348F /* Data */,
 				92ADC09D263B6696009B348F /* Formatting */,
-				922C1D10263A573500F34AE9 /* Info.plist */,
 				922C1D0D263A573500F34AE9 /* Preview Content */,
 				92F4F85C263AE97C00205600 /* Views */,
 			);

--- a/Fasting.xcodeproj/xcshareddata/xcschemes/WatchFasting (Complication).xcscheme
+++ b/Fasting.xcodeproj/xcshareddata/xcschemes/WatchFasting (Complication).xcscheme
@@ -55,10 +55,8 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "32">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Sunrise">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "922C1CF2263A573400F34AE9"
@@ -66,7 +64,7 @@
             BlueprintName = "WatchFasting"
             ReferencedContainer = "container:Fasting.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -75,10 +73,8 @@
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "32">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Sunrise">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "922C1CF2263A573400F34AE9"
@@ -86,16 +82,7 @@
             BlueprintName = "WatchFasting"
             ReferencedContainer = "container:Fasting.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "922C1CF2263A573400F34AE9"
-            BuildableName = "WatchFasting.app"
-            BlueprintName = "WatchFasting"
-            ReferencedContainer = "container:Fasting.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Fasting.xcodeproj/xcshareddata/xcschemes/WatchFasting.xcscheme
+++ b/Fasting.xcodeproj/xcshareddata/xcschemes/WatchFasting.xcscheme
@@ -54,10 +54,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Sunrise">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "922C1CF2263A573400F34AE9"
@@ -65,7 +63,7 @@
             BlueprintName = "WatchFasting"
             ReferencedContainer = "container:Fasting.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,10 +71,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Sunrise">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "922C1CF2263A573400F34AE9"
@@ -84,16 +80,7 @@
             BlueprintName = "WatchFasting"
             ReferencedContainer = "container:Fasting.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "922C1CF2263A573400F34AE9"
-            BuildableName = "WatchFasting.app"
-            BlueprintName = "WatchFasting"
-            ReferencedContainer = "container:Fasting.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Fasting/Storage/Extensions/UserDefaults+Publishing.swift
+++ b/Fasting/Storage/Extensions/UserDefaults+Publishing.swift
@@ -17,8 +17,12 @@ extension UserDefaults {
   func publisher<T>(for key: UserDefaultKey) -> AnyPublisher<T?, Never> {
     
     return NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
-      .compactMap { (notification: Notification) -> UserDefaults? in
-        return notification.object as? UserDefaults
+      .compactMap { [weak self] (notification: Notification) -> UserDefaults? in
+        
+        guard let object: UserDefaults = notification.object as? UserDefaults, object == self else {
+          return nil
+        }
+        return object
       }
       .prepend(self)
       .map { (defaults: UserDefaults) -> T? in


### PR DESCRIPTION
Fixes #27. When subscribing to a UserDefault change, we didn't guard against other defaults sending notifications. This update filters out changes from defaults we're not subscribed to.