### PR TITLE
Send update to watch from app

### DIFF
--- a/WatchFasting Extension/Data/DataModel/WatchDataModel+WCSessionDelegate.swift
+++ b/WatchFasting Extension/Data/DataModel/WatchDataModel+WCSessionDelegate.swift
@@ -32,6 +32,17 @@ extension WatchDataModel: WCSessionDelegate {
       self.decodeAppDataUpdate(messageData)
     }
   }
+  
+  // We received new user info
+  func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any] = [:]) {
+    do {
+      let data = try JSONSerialization.data(withJSONObject: userInfo, options: [])
+      decodeAppDataUpdate(data)
+      
+    } catch {
+      logger.error("Unable to parse json: \(error.localizedDescription)")
+    }
+  }
 
   private func decodeAppDataUpdate(_ data: Data) {
 


### PR DESCRIPTION
Currently you must open the watch app in order to see any updates made by the companion phone app. This PR sends updates to the watch when they're made from the phone.